### PR TITLE
Fixed res._headers deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class ExpressLruCache {
                     var nocache = res.statusCode && res.statusCode !== 200;
                     callback(nocache, {
                         body: body,
-                        headers: res._headers,
+                        headers: res.getHeaders(),
                         status: res.statusCode
                     });
                 };


### PR DESCRIPTION
Fixed warning 'OutgoingMessage.prototype._headers is deprecated' by replacing `res._headers` with `res.getHeaders()`

Used suggested option in Deprecated APIs: https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames

Thanks for the great library!